### PR TITLE
Camera barcode

### DIFF
--- a/shopBuddy/shopBuddy.xcodeproj/project.pbxproj
+++ b/shopBuddy/shopBuddy.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		061C55EB287E284F00033418 /* AddItemViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 061C55EA287E284F00033418 /* AddItemViewController.m */; };
 		061C55F2287E303C00033418 /* Item.m in Sources */ = {isa = PBXBuildFile; fileRef = 061C55ED287E303C00033418 /* Item.m */; };
 		061C55F4287E303C00033418 /* Trip.m in Sources */ = {isa = PBXBuildFile; fileRef = 061C55F1287E303C00033418 /* Trip.m */; };
+		064A476D28809E8800AEF527 /* ScanBarcodeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 064A476C28809E8800AEF527 /* ScanBarcodeViewController.m */; };
 		06644835287774D300D89317 /* ProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 06644834287774D300D89317 /* ProfileViewController.m */; };
 		06A377122875FE2500A6AA7D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 06A377112875FE2500A6AA7D /* AppDelegate.m */; };
 		06A377152875FE2500A6AA7D /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 06A377142875FE2500A6AA7D /* SceneDelegate.m */; };
@@ -58,6 +59,8 @@
 		061C55ED287E303C00033418 /* Item.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Item.m; sourceTree = "<group>"; };
 		061C55F0287E303C00033418 /* Trip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Trip.h; sourceTree = "<group>"; };
 		061C55F1287E303C00033418 /* Trip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Trip.m; sourceTree = "<group>"; };
+		064A476B28809E8800AEF527 /* ScanBarcodeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScanBarcodeViewController.h; sourceTree = "<group>"; };
+		064A476C28809E8800AEF527 /* ScanBarcodeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ScanBarcodeViewController.m; sourceTree = "<group>"; };
 		06644833287774D300D89317 /* ProfileViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProfileViewController.h; sourceTree = "<group>"; };
 		06644834287774D300D89317 /* ProfileViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProfileViewController.m; sourceTree = "<group>"; };
 		06A3770D2875FE2500A6AA7D /* shopBuddy.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = shopBuddy.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -159,6 +162,8 @@
 				06A377162875FE2500A6AA7D /* ViewController.h */,
 				06A377172875FE2500A6AA7D /* ViewController.m */,
 				06A377192875FE2500A6AA7D /* Main.storyboard */,
+				064A476B28809E8800AEF527 /* ScanBarcodeViewController.h */,
+				064A476C28809E8800AEF527 /* ScanBarcodeViewController.m */,
 				061C55E9287E284F00033418 /* AddItemViewController.h */,
 				061C55EA287E284F00033418 /* AddItemViewController.m */,
 				06644833287774D300D89317 /* ProfileViewController.h */,
@@ -463,6 +468,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				064A476D28809E8800AEF527 /* ScanBarcodeViewController.m in Sources */,
 				061C55F4287E303C00033418 /* Trip.m in Sources */,
 				06A3774A287605AD00A6AA7D /* ShoppingListViewController.m in Sources */,
 				06A377182875FE2500A6AA7D /* ViewController.m in Sources */,

--- a/shopBuddy/shopBuddy/APIManager.m
+++ b/shopBuddy/shopBuddy/APIManager.m
@@ -40,7 +40,6 @@ AFHTTPSessionManager *manager;
     [manager GET:path parameters:nil headers: nil progress:nil success:^(NSURLSessionTask *task, NSDictionary *responseObject)
      {
          // Success
-         NSLog(@"Success: %@", responseObject);
         //TODO: Validate server response
         Item *item = [[Item alloc] initWithDictionary:responseObject[@"products"][0]];
         completion(item, nil);

--- a/shopBuddy/shopBuddy/APIManager.m
+++ b/shopBuddy/shopBuddy/APIManager.m
@@ -26,8 +26,7 @@ AFHTTPSessionManager *manager;
     if(self=[super init])
     {
         manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:baseURLString]];
-        NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile: [[NSBundle mainBundle] pathForResource: @"Keys" ofType: @"plist"]];
-        key = [dict objectForKey: @"api_key"];
+        key = [[NSDictionary dictionaryWithContentsOfFile: [[NSBundle mainBundle] pathForResource: @"Keys" ofType: @"plist"]] objectForKey: @"api_key"];
     }
     return self;
 }
@@ -47,7 +46,6 @@ AFHTTPSessionManager *manager;
      {
          // Failure
         //TODO: Failure logic
-         NSLog(@"Failure: %@", error);
      }];
     
     

--- a/shopBuddy/shopBuddy/AddItemViewController.h
+++ b/shopBuddy/shopBuddy/AddItemViewController.h
@@ -7,6 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import "Item.h"
+#import <AVFoundation/AVFoundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/shopBuddy/shopBuddy/AddItemViewController.h
+++ b/shopBuddy/shopBuddy/AddItemViewController.h
@@ -7,7 +7,6 @@
 
 #import <UIKit/UIKit.h>
 #import "Item.h"
-#import <AVFoundation/AVFoundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/shopBuddy/shopBuddy/AddItemViewController.m
+++ b/shopBuddy/shopBuddy/AddItemViewController.m
@@ -36,9 +36,7 @@
     {
         ItemDetailViewController *detailVC = [segue destinationViewController];
         detailVC.barcode = self.barcodeField.text;
-    }
-    else if([segue.identifier isEqual:@"showBarcodeSegue"])
-    {
+    } else if([segue.identifier isEqual:@"showBarcodeSegue"]) {
         ScanBarcodeViewController *barcodeVC = [segue destinationViewController];
     }
 }

--- a/shopBuddy/shopBuddy/AddItemViewController.m
+++ b/shopBuddy/shopBuddy/AddItemViewController.m
@@ -9,7 +9,6 @@
 #import "APIManager.h"
 #import "Item.h"
 #import "ItemDetailViewController.h"
-#import <AVFoundation/AVFoundation.h>
 #import "ScanBarcodeViewController.h"
 
 @interface AddItemViewController ()
@@ -22,9 +21,11 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 }
+
 - (IBAction)didTapScanBarcode:(id)sender {
     [self performSegueWithIdentifier:@"showBarcodeSegue" sender:self];
 }
+
 - (IBAction)didTapGetItem:(id)sender {
     [self performSegueWithIdentifier:@"showDetailSegue" sender:self];
     

--- a/shopBuddy/shopBuddy/AddItemViewController.m
+++ b/shopBuddy/shopBuddy/AddItemViewController.m
@@ -9,6 +9,8 @@
 #import "APIManager.h"
 #import "Item.h"
 #import "ItemDetailViewController.h"
+#import <AVFoundation/AVFoundation.h>
+#import "ScanBarcodeViewController.h"
 
 @interface AddItemViewController ()
 @property (weak, nonatomic) IBOutlet UITextField *barcodeField;
@@ -20,19 +22,24 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 }
+- (IBAction)didTapScanBarcode:(id)sender {
+    [self performSegueWithIdentifier:@"showBarcodeSegue" sender:self];
+}
 - (IBAction)didTapGetItem:(id)sender {
     [self performSegueWithIdentifier:@"showDetailSegue" sender:self];
     
 }
 
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-*/
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    ItemDetailViewController *detailVC = [segue destinationViewController];
-    detailVC.barcode = self.barcodeField.text;
+    if([segue.identifier isEqual:@"showDetailSegue"])
+    {
+        ItemDetailViewController *detailVC = [segue destinationViewController];
+        detailVC.barcode = self.barcodeField.text;
+    }
+    else if([segue.identifier isEqual:@"showBarcodeSegue"])
+    {
+        ScanBarcodeViewController *barcodeVC = [segue destinationViewController];
+    }
 }
 
 @end

--- a/shopBuddy/shopBuddy/Base.lproj/Main.storyboard
+++ b/shopBuddy/shopBuddy/Base.lproj/Main.storyboard
@@ -109,21 +109,37 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CFI-dU-HwV">
-                                <rect key="frame" x="107" y="150" width="201" height="41"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Get Sample Item"/>
-                                <connections>
-                                    <action selector="didTapGetItem:" destination="DU9-0J-PMc" eventType="touchUpInside" id="NNU-VN-M8v"/>
-                                </connections>
-                            </button>
                             <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="3614272049529" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1vQ-Ye-R8K">
                                 <rect key="frame" x="139" y="115" width="137" height="34"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zJA-qT-Wtm">
+                                <rect key="frame" x="151" y="411" width="114" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Scan Barcode"/>
+                                <connections>
+                                    <action selector="didTapScanBarcode:" destination="DU9-0J-PMc" eventType="touchUpInside" id="u2e-1Q-AEp"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="OR" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rHi-Ow-tpd">
+                                <rect key="frame" x="187" y="292" width="24" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CFI-dU-HwV">
+                                <rect key="frame" x="62" y="157" width="291" height="41"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Get Sample Item from Barcode"/>
+                                <connections>
+                                    <action selector="didTapGetItem:" destination="DU9-0J-PMc" eventType="touchUpInside" id="NNU-VN-M8v"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="l9D-6K-XzS"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -131,6 +147,7 @@
                     <connections>
                         <outlet property="barcodeField" destination="1vQ-Ye-R8K" id="P9H-A8-bmD"/>
                         <segue destination="81r-ja-Gg9" kind="show" identifier="showDetailSegue" id="op9-hX-QNT"/>
+                        <segue destination="CGZ-BZ-W37" kind="show" identifier="showBarcodeSegue" id="RXD-sV-kYU"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xEe-r7-aCG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -273,6 +290,58 @@
             </objects>
             <point key="canvasLocation" x="2350.7246376811595" y="835.71428571428567"/>
         </scene>
+        <!--Scan Barcode View Controller-->
+        <scene sceneID="M2z-po-CpA">
+            <objects>
+                <viewController id="CGZ-BZ-W37" customClass="ScanBarcodeViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="yJ5-c0-Wue">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="e98-95-Kaw">
+                                <rect key="frame" x="0.0" y="96" width="414" height="652"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="labelColor"/>
+                            </view>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="10r-L6-BoQ">
+                                <rect key="frame" x="0.0" y="748" width="414" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                <items>
+                                    <barButtonItem width="141" style="plain" systemItem="fixedSpace" id="vr2-Yt-i26"/>
+                                    <barButtonItem title="Start Scanning" id="sWu-N3-Kej">
+                                        <connections>
+                                            <action selector="startStopScanning:" destination="CGZ-BZ-W37" id="Vzk-rU-189"/>
+                                        </connections>
+                                    </barButtonItem>
+                                    <barButtonItem style="plain" systemItem="fixedSpace" id="POP-uT-1EC"/>
+                                </items>
+                            </toolbar>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uaD-oR-vX1">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="88"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Lookup"/>
+                                <connections>
+                                    <action selector="didTapLookup:" destination="CGZ-BZ-W37" eventType="touchUpInside" id="CLW-Ti-NPH"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6wz-tm-CMP"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <toolbarItems/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="lookupButton" destination="uaD-oR-vX1" id="RLG-tY-aZz"/>
+                        <outlet property="preview" destination="e98-95-Kaw" id="ZZ1-kp-GaW"/>
+                        <outlet property="scanButton" destination="sWu-N3-Kej" id="6An-Z6-CbP"/>
+                        <segue destination="81r-ja-Gg9" kind="show" identifier="showItemDetailView" id="JT3-aC-7fp"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jgk-Mb-4ro" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3527.5362318840585" y="795.53571428571422"/>
+        </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="2zb-DL-zmc">
             <objects>
@@ -312,6 +381,9 @@
             <point key="canvasLocation" x="1500.0000000000002" y="850.44642857142856"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="op9-hX-QNT"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="list.bullet.rectangle.portrait" catalog="system" width="115" height="128"/>
         <image name="person" catalog="system" width="128" height="117"/>

--- a/shopBuddy/shopBuddy/Base.lproj/Main.storyboard
+++ b/shopBuddy/shopBuddy/Base.lproj/Main.storyboard
@@ -163,7 +163,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Item Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rD6-qL-EmS">
-                                <rect key="frame" x="168" y="94" width="236" height="25"/>
+                                <rect key="frame" x="168" y="50" width="236" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="25" id="LGh-B4-08T"/>
                                 </constraints>
@@ -172,7 +172,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Brand" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D5h-Sv-3zT">
-                                <rect key="frame" x="168" y="129" width="236" height="25"/>
+                                <rect key="frame" x="168" y="85" width="236" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="25" id="GK9-00-8Pq"/>
                                 </constraints>
@@ -181,14 +181,14 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1nA-O7-BHv">
-                                <rect key="frame" x="20" y="94" width="128" height="128"/>
+                                <rect key="frame" x="20" y="50" width="128" height="128"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="c4q-4X-cV6"/>
                                     <constraint firstAttribute="width" constant="128" id="wpd-fQ-fQR"/>
                                 </constraints>
                             </imageView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Qf0-3I-xWT">
-                                <rect key="frame" x="168" y="179" width="236" height="150"/>
+                                <rect key="frame" x="168" y="135" width="236" height="150"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="150" id="Mpe-qK-Sgp"/>
@@ -332,9 +332,9 @@
                     <toolbarItems/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="lookupButton" destination="uaD-oR-vX1" id="RLG-tY-aZz"/>
-                        <outlet property="preview" destination="e98-95-Kaw" id="ZZ1-kp-GaW"/>
-                        <outlet property="scanButton" destination="sWu-N3-Kej" id="6An-Z6-CbP"/>
+                        <outlet property="lookupButton" destination="uaD-oR-vX1" id="wFI-WO-OBh"/>
+                        <outlet property="preview" destination="e98-95-Kaw" id="uht-Td-arB"/>
+                        <outlet property="scanButton" destination="sWu-N3-Kej" id="9yK-rs-2jV"/>
                         <segue destination="81r-ja-Gg9" kind="show" identifier="showItemDetailView" id="JT3-aC-7fp"/>
                     </connections>
                 </viewController>
@@ -382,7 +382,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="op9-hX-QNT"/>
+        <segue reference="JT3-aC-7fp"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="list.bullet.rectangle.portrait" catalog="system" width="115" height="128"/>

--- a/shopBuddy/shopBuddy/Info.plist
+++ b/shopBuddy/shopBuddy/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>shopBuddy Camera Usage</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/shopBuddy/shopBuddy/ItemDetailViewController.m
+++ b/shopBuddy/shopBuddy/ItemDetailViewController.m
@@ -24,9 +24,7 @@
     [super viewDidLoad];
     self.descriptionView.scrollEnabled=YES;
     [[APIManager shared] getItemWithBarcode:self.barcode completion:^(Item *item, NSError *error) {
-        NSLog(@"😎😎😎 Successfully loaded itemDetails");
         if (item) {
-            NSLog(@"😎😎😎 Successfully loaded itemDetails");
             self.item = item;
             self.titleLabel.text = self.item.name;
             self.brandLabel.text = self.item.brand;

--- a/shopBuddy/shopBuddy/ScanBarcodeViewController.h
+++ b/shopBuddy/shopBuddy/ScanBarcodeViewController.h
@@ -1,0 +1,26 @@
+//
+//  ScanBarcodeViewController.h
+//  shopBuddy
+//
+//  Created by Rachna Gupta on 7/14/22.
+//
+
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ScanBarcodeViewController : UIViewController <AVCaptureMetadataOutputObjectsDelegate>
+@property (nonatomic) BOOL isScanning;
+@property (nonatomic, strong) AVCaptureSession *captureSession;
+@property (nonatomic, strong) AVCaptureVideoPreviewLayer *videoPreviewLayer;
+
+
+-(BOOL)startScanning;
+-(void)captureOutput:(AVCaptureOutput *)captureOutput didOutputMetadataObjects:(NSArray *)metadataObjects fromConnection:(AVCaptureConnection *)connection;
+-(void)updateWithBarcode:(NSString *)barcode;
+-(void)stopScanning;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/shopBuddy/shopBuddy/ScanBarcodeViewController.h
+++ b/shopBuddy/shopBuddy/ScanBarcodeViewController.h
@@ -11,16 +11,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ScanBarcodeViewController : UIViewController <AVCaptureMetadataOutputObjectsDelegate>
-@property (nonatomic) BOOL isScanning;
-@property (nonatomic, strong) AVCaptureSession *captureSession;
-@property (nonatomic, strong) AVCaptureVideoPreviewLayer *videoPreviewLayer;
-
-
--(BOOL)startScanning;
--(void)captureOutput:(AVCaptureOutput *)captureOutput didOutputMetadataObjects:(NSArray *)metadataObjects fromConnection:(AVCaptureConnection *)connection;
--(void)updateWithBarcode:(NSString *)barcode;
--(void)stopScanning;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/shopBuddy/shopBuddy/ScanBarcodeViewController.m
+++ b/shopBuddy/shopBuddy/ScanBarcodeViewController.m
@@ -10,34 +10,40 @@
 #import "ItemDetailViewController.h"
 
 @interface ScanBarcodeViewController ()
-@property (weak, nonatomic) IBOutlet UIView *preview;
-@property (weak, nonatomic) IBOutlet UIBarButtonItem *scanButton;
-@property (weak, nonatomic) IBOutlet UIButton *lookupButton;
-@property NSString *barcode;
+{
+    BOOL isScanning;
+    AVCaptureSession *captureSession;
+    AVCaptureVideoPreviewLayer *videoPreviewLayer;
+    NSString *barcode;
+    __weak IBOutlet UIView *preview;
+    __weak IBOutlet UIBarButtonItem *scanButton;
+    __weak IBOutlet UIButton *lookupButton;
+    
+}
 
 @end
 @implementation ScanBarcodeViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    _isScanning = NO;
-    _captureSession = nil;
-    [_lookupButton setTitle:@" " forState:UIControlStateNormal];
+    isScanning = NO;
+    captureSession = nil;
+    [lookupButton setTitle:@" " forState:UIControlStateNormal];
     
 }
 //changes the boolean property if the stop/start button is pressed
 - (IBAction)startStopScanning:(id)sender {
-    if (!_isScanning) {
+    if (!isScanning) {
             if ([self startScanning]) {
-                [_scanButton setTitle:@"Stop Scanning"];
+                [scanButton setTitle:@"Stop Scanning"];
             }
         }
         else{
             [self stopScanning];
-            [_scanButton setTitle:@"Start Scanning"];
+            [scanButton setTitle:@"Start Scanning"];
         }
         
-        _isScanning = !_isScanning;
+    isScanning = !isScanning;
     }
 //starts scanning for barcodes (metadata objects) and runs the capturesession
 - (BOOL)startScanning {
@@ -47,22 +53,21 @@
     AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error];
      
         if (!input) {
-            NSLog(@"%@", [error localizedDescription]);
             return NO;
         }
-    _captureSession = [[AVCaptureSession alloc] init];
-        [_captureSession addInput:input];
+    captureSession = [[AVCaptureSession alloc] init];
+    [captureSession addInput:input];
     AVCaptureMetadataOutput *captureMetadataOutput = [[AVCaptureMetadataOutput alloc] init];
-        [_captureSession addOutput:captureMetadataOutput];
+        [captureSession addOutput:captureMetadataOutput];
     dispatch_queue_t dispatchQueue;
         dispatchQueue = dispatch_queue_create("myQueue", NULL);
         [captureMetadataOutput setMetadataObjectsDelegate:self queue:dispatchQueue];
         [captureMetadataOutput setMetadataObjectTypes:[NSArray arrayWithObject:AVMetadataObjectTypeEAN13Code]];
-        _videoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:_captureSession];
-        [_videoPreviewLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
-        [_videoPreviewLayer setFrame:_preview.layer.bounds];
-        [_preview.layer addSublayer:_videoPreviewLayer];
-    [_captureSession startRunning];
+        videoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:captureSession];
+        [videoPreviewLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
+        [videoPreviewLayer setFrame:preview.layer.bounds];
+        [preview.layer addSublayer:videoPreviewLayer];
+    [captureSession startRunning];
     return YES;
     
 }
@@ -71,22 +76,22 @@
     if (metadataObjects != nil && [metadataObjects count] > 0) {
         AVMetadataMachineReadableCodeObject *metadataObj = [metadataObjects objectAtIndex:0];
             [self performSelectorOnMainThread:@selector(stopScanning) withObject:nil waitUntilDone:NO];
-        [_scanButton performSelectorOnMainThread:@selector(setTitle:) withObject:@"Start Scanning" waitUntilDone:NO];
+        [scanButton performSelectorOnMainThread:@selector(setTitle:) withObject:@"Start Scanning" waitUntilDone:NO];
         [self performSelectorOnMainThread:@selector(updateWithBarcode:) withObject:[metadataObj stringValue] waitUntilDone:NO];
-                _isScanning = NO;
+                isScanning = NO;
         }
     }
 
 //updates the lookup button and the _barcode variable to reflect the new barcode
--(void)updateWithBarcode:(NSString *)barcode {
-    [_lookupButton setTitle:[NSString stringWithFormat:@"Lookup Item with Barcode %@",barcode] forState:UIControlStateNormal];
-    _barcode = barcode;
+-(void)updateWithBarcode:(NSString *)givenBarcode {
+    [lookupButton setTitle:[NSString stringWithFormat:@"Lookup Item with Barcode %@",givenBarcode] forState:UIControlStateNormal];
+    barcode = givenBarcode;
 }
 //this method stops the capture session
 -(void)stopScanning{
-    [_captureSession stopRunning];
-    _captureSession = nil;
-    [_videoPreviewLayer removeFromSuperlayer];
+    [captureSession stopRunning];
+    captureSession = nil;
+    [videoPreviewLayer removeFromSuperlayer];
 }
 
 //triggers segue to detail view
@@ -100,7 +105,7 @@
     if([segue.identifier isEqual:@"showItemDetailView"])
     {
         ItemDetailViewController *detailVC = [segue destinationViewController];
-        detailVC.barcode = _barcode;
+        detailVC.barcode = barcode;
     }
 }
 

--- a/shopBuddy/shopBuddy/ScanBarcodeViewController.m
+++ b/shopBuddy/shopBuddy/ScanBarcodeViewController.m
@@ -28,25 +28,25 @@
     [super viewDidLoad];
     isScanning = NO;
     captureSession = nil;
-    [lookupButton setTitle:@" " forState:UIControlStateNormal];
+    [lookupButton setTitle:@"" forState:UIControlStateNormal];
     
 }
 
 //changes the boolean property if the stop/start button is pressed
 - (IBAction)startStopScanning:(id)sender {
     if (!isScanning) {
-        if ([self startScanning]) {
+        if ([self _startScanning]) {
             [scanButton setTitle:@"Stop Scanning"];
         }
     } else {
-        [self stopScanning];
+        [self _stopScanning];
         [scanButton setTitle:@"Start Scanning"];
     }
     isScanning = !isScanning;
 }
 
 //starts scanning for barcodes (metadata objects) and runs the capturesession
-- (BOOL)startScanning {
+- (BOOL)_startScanning {
     NSError *error;
  
     AVCaptureDevice *captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
@@ -70,14 +70,14 @@
 }
 
 //updates the lookup button and the _barcode variable to reflect the new barcode
--(void)updateWithBarcode:(NSString *)givenBarcode {
+-(void)_updateWithBarcode:(NSString *)givenBarcode {
     [lookupButton setTitle:[NSString stringWithFormat:@"Lookup Item with Barcode %@",givenBarcode] forState:UIControlStateNormal];
     barcode = givenBarcode;
     //TODO: Validate Barcode
 }
 
 //this method stops the capture session
--(void)stopScanning{
+-(void)_stopScanning{
     [captureSession stopRunning];
     captureSession = nil;
     [videoPreviewLayer removeFromSuperlayer];
@@ -96,17 +96,18 @@
         detailVC.barcode = barcode;
     }
 }
+
 #pragma mark - AVCaptureMetadataOutputObjectsDelegate
 
 //run when an object is captured (a barcode is scanned)
 -(void)captureOutput:(AVCaptureOutput *)captureOutput didOutputMetadataObjects:(NSArray *)metadataObjects fromConnection:(AVCaptureConnection *)connection {
-    if (metadataObjects != nil && [metadataObjects count] > 0) {
+    if ([metadataObjects count] > 0) {
         AVMetadataMachineReadableCodeObject *const metadataObj = [metadataObjects objectAtIndex:0];
-        [self performSelectorOnMainThread:@selector(stopScanning) withObject:nil waitUntilDone:NO];
+        [self performSelectorOnMainThread:@selector(_stopScanning) withObject:nil waitUntilDone:NO];
         [scanButton performSelectorOnMainThread:@selector(setTitle:) withObject:@"Start Scanning" waitUntilDone:NO];
-        [self performSelectorOnMainThread:@selector(updateWithBarcode:) withObject:[metadataObj stringValue] waitUntilDone:NO];
+        [self performSelectorOnMainThread:@selector(_updateWithBarcode:) withObject:[metadataObj stringValue] waitUntilDone:NO];
         isScanning = NO;
-        }
     }
+}
 
 @end

--- a/shopBuddy/shopBuddy/ScanBarcodeViewController.m
+++ b/shopBuddy/shopBuddy/ScanBarcodeViewController.m
@@ -38,8 +38,7 @@
         if ([self startScanning]) {
             [scanButton setTitle:@"Stop Scanning"];
         }
-    }
-    else{
+    } else {
         [self stopScanning];
         [scanButton setTitle:@"Start Scanning"];
     }
@@ -74,6 +73,7 @@
 -(void)updateWithBarcode:(NSString *)givenBarcode {
     [lookupButton setTitle:[NSString stringWithFormat:@"Lookup Item with Barcode %@",givenBarcode] forState:UIControlStateNormal];
     barcode = givenBarcode;
+    //TODO: Validate Barcode
 }
 
 //this method stops the capture session

--- a/shopBuddy/shopBuddy/ScanBarcodeViewController.m
+++ b/shopBuddy/shopBuddy/ScanBarcodeViewController.m
@@ -1,0 +1,107 @@
+//
+//  ScanBarcodeViewController.m
+//  shopBuddy
+//
+//  Created by Rachna Gupta on 7/14/22.
+//
+
+#import "ScanBarcodeViewController.h"
+#import "AVFoundation/AVFoundation.h"
+#import "ItemDetailViewController.h"
+
+@interface ScanBarcodeViewController ()
+@property (weak, nonatomic) IBOutlet UIView *preview;
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *scanButton;
+@property (weak, nonatomic) IBOutlet UIButton *lookupButton;
+@property NSString *barcode;
+
+@end
+@implementation ScanBarcodeViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    _isScanning = NO;
+    _captureSession = nil;
+    [_lookupButton setTitle:@" " forState:UIControlStateNormal];
+    
+}
+//changes the boolean property if the stop/start button is pressed
+- (IBAction)startStopScanning:(id)sender {
+    if (!_isScanning) {
+            if ([self startScanning]) {
+                [_scanButton setTitle:@"Stop Scanning"];
+            }
+        }
+        else{
+            [self stopScanning];
+            [_scanButton setTitle:@"Start Scanning"];
+        }
+        
+        _isScanning = !_isScanning;
+    }
+//starts scanning for barcodes (metadata objects) and runs the capturesession
+- (BOOL)startScanning {
+    NSError *error;
+ 
+    AVCaptureDevice *captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+    AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error];
+     
+        if (!input) {
+            NSLog(@"%@", [error localizedDescription]);
+            return NO;
+        }
+    _captureSession = [[AVCaptureSession alloc] init];
+        [_captureSession addInput:input];
+    AVCaptureMetadataOutput *captureMetadataOutput = [[AVCaptureMetadataOutput alloc] init];
+        [_captureSession addOutput:captureMetadataOutput];
+    dispatch_queue_t dispatchQueue;
+        dispatchQueue = dispatch_queue_create("myQueue", NULL);
+        [captureMetadataOutput setMetadataObjectsDelegate:self queue:dispatchQueue];
+        [captureMetadataOutput setMetadataObjectTypes:[NSArray arrayWithObject:AVMetadataObjectTypeEAN13Code]];
+        _videoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:_captureSession];
+        [_videoPreviewLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
+        [_videoPreviewLayer setFrame:_preview.layer.bounds];
+        [_preview.layer addSublayer:_videoPreviewLayer];
+    [_captureSession startRunning];
+    return YES;
+    
+}
+//run when an object is captured (a barcode is scanned)
+-(void)captureOutput:(AVCaptureOutput *)captureOutput didOutputMetadataObjects:(NSArray *)metadataObjects fromConnection:(AVCaptureConnection *)connection{
+    if (metadataObjects != nil && [metadataObjects count] > 0) {
+        AVMetadataMachineReadableCodeObject *metadataObj = [metadataObjects objectAtIndex:0];
+            [self performSelectorOnMainThread:@selector(stopScanning) withObject:nil waitUntilDone:NO];
+        [_scanButton performSelectorOnMainThread:@selector(setTitle:) withObject:@"Start Scanning" waitUntilDone:NO];
+        [self performSelectorOnMainThread:@selector(updateWithBarcode:) withObject:[metadataObj stringValue] waitUntilDone:NO];
+                _isScanning = NO;
+        }
+    }
+
+//updates the lookup button and the _barcode variable to reflect the new barcode
+-(void)updateWithBarcode:(NSString *)barcode {
+    [_lookupButton setTitle:[NSString stringWithFormat:@"Lookup Item with Barcode %@",barcode] forState:UIControlStateNormal];
+    _barcode = barcode;
+}
+//this method stops the capture session
+-(void)stopScanning{
+    [_captureSession stopRunning];
+    _captureSession = nil;
+    [_videoPreviewLayer removeFromSuperlayer];
+}
+
+//triggers segue to detail view
+- (IBAction)didTapLookup:(id)sender {
+    [self performSegueWithIdentifier:@"showItemDetailView" sender:self];
+
+}
+
+//sends barcode info to detail view
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    if([segue.identifier isEqual:@"showItemDetailView"])
+    {
+        ItemDetailViewController *detailVC = [segue destinationViewController];
+        detailVC.barcode = _barcode;
+    }
+}
+
+@end


### PR DESCRIPTION
# Camera Barcode

## Summary:

added ScanBarcode screen where user can start and stop scanning session and scan a barcode, which will then be returned back to the user for confirmation before seguing to the itemDetailView. 

## Milestone: [(e.g. Pricing API)]

- [x] Get comfortable with Remodel and use it to construct models like List, Item, etc
- [x] Create ItemDetailView and prelim version of ShoppingListView
- [x] Retrieve product info from barcode https://www.barcodelookup.com/api-documentation#endpoints
- [X] Use camera to scan barcode
- [ ] Implement search for items with corresponding picture and info in TableView

## Test Plan:
Navigate to the Add an Item page and click Scan Barcode. Click Start scanning and point the camera at a barcode. Click the button to look up the barcode given and view details. 
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/51427351/179122465-f95ddba9-6bbc-47ef-a14c-b8037afc0a87.gif)

